### PR TITLE
Prior Art

### DIFF
--- a/PriorArt.md
+++ b/PriorArt.md
@@ -1,0 +1,26 @@
+# Prior Art
+
+This file contains a simple list of projects, individuals, institutes _etc_ which have made similar or relevant declarations regarding Open Science. We separate this into sections : 
+
+  * Declarations - similar declarations which we base ours on
+  * Relevant Articles - Scholarly articles which make the case for Open Science
+  * Initiatives - projects, initiatives etc which promote or support activities in Open Science
+
+If you would like to extend this list, please see [how to contribute](CONTRIBUTING.md). Ensure that you provide  persistent links to the objects you wish to cite, wherever possible. 
+
+
+# Declarations
+
+# Scholarly Communication
+
+## Journal Articles
+
+## Relevant Twitter Accounts
+
+## Blogs
+
+# Inititatives
+
+
+  
+  

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Signatory of the declaration can be done via a web form at [sci-gaia.eu/dakar-de
 
 Versions of the declaration are assigned individual DOIs. The first version is published at [doi:11623/sci-gaia:1457961379.87](http://dx.doi.org/11623/sci-gaia:1457961379.87), and this should be used as the source when citing the declaration.
 
+## Prior Art
+
+This  declaration is based on previous work and declarations by a diverse set of individuals, projects, institutes _etc_. We try to keep a tab on these, with a brief comment on their relevance in the [prior art](PriorArt.md) file.
+
 ## Treatment of personal data
 
 Personal data submitted via the web form will be stored in a private database, for the express purpose of validating submissions and publishing the name of the signatory. No contact informatio will be shared with anyone. The information in the database will be protected by the members of the Sci-GaIA consortium, and the future treatment of the data will be decided at the end of the project by internal review.


### PR DESCRIPTION
It's going to be very difficult to keep track of the network of interest and support that this declaration might have. I have included this file as a simple way to keep track of the various ways others have been engaged in the topic of open science, as well as to properly reference prior art for those who wish to use this Declaration.
